### PR TITLE
Kafka datetime encoding

### DIFF
--- a/openstates/scrape/base.py
+++ b/openstates/scrape/base.py
@@ -223,7 +223,11 @@ class Scraper(scrapelib.Scraper):
                 kafka_brokers = response['BootstrapBrokerStringTls']
 
                 # Instantiate KafkaProducer and Send Bill JSON to State Topic
-                producer = KafkaProducer(security_protocol="SSL", bootstrap_servers=kafka_brokers, value_serializer=lambda v: json.dumps(v).encode('utf-8'))
+                producer = KafkaProducer(
+                    security_protocol="SSL", 
+                    bootstrap_servers=kafka_brokers, 
+                    value_serializer=lambda v: json.dumps(v, cls=JSONEncoderPlus).encode('utf-8')
+                )                
                 producer.send(jurisdiction, obj.as_dict()) # Sending the Bill JSON to a State Topic
                 
                 # Kafka producers use batching to optimize throughput and reduce the load on brokers

--- a/openstates/scrape/base.py
+++ b/openstates/scrape/base.py
@@ -226,7 +226,7 @@ class Scraper(scrapelib.Scraper):
                 producer = KafkaProducer(
                     security_protocol="SSL", 
                     bootstrap_servers=kafka_brokers, 
-                    value_serializer=lambda v: json.dumps(v, cls=JSONEncoderPlus).encode('utf-8')
+                    value_serializer=lambda v: json.dumps(v, cls=utils.JSONEncoderPlus).encode('utf-8')
                 )                
                 producer.send(jurisdiction, obj.as_dict()) # Sending the Bill JSON to a State Topic
                 


### PR DESCRIPTION
This PR adds in a small fix to the Kafka Producer instantiation.  Specifically, we are using the `JSONEncoder` function to transform `datetime` values into strings.  We do this because we are unable to send `datetime` values to Kafka clusters.