### PR TITLE
legislative_sessions update

### DIFF
--- a/openstates/scrape/jurisdiction.py
+++ b/openstates/scrape/jurisdiction.py
@@ -86,6 +86,17 @@ class State(BaseModel):
         self,
         endpoint: str = os.getenv("CRONOS_ENDPOINT"),
     ):
+        """Requires CRONOS_ENDPOINT for getting the legislative sessions. Note that legislative sessions are retrieved as a list of json objects.
+
+        The legislative sessions appear in the following format
+        {
+            "identifier": "2021",
+            "name": "2021 Regular Session",
+            "start_date": "2021-01-01",
+            "end_date": "2021-12-31",
+            "classification": "primary", # primary or special
+            }
+        """
         params = {"state_name": self.name}
         response = requests.get(
             endpoint,
@@ -96,6 +107,9 @@ class State(BaseModel):
 
     @property
     def legislative_sessions(self, opt_for_new: bool = False):
+        """Returns a list of legislative sessions. If opt_for_new is True, it will override the historical sessions with the new ones from cronos. Otherwise,
+        any sessions from cronos with the same identifier as the historical ones will not be used.
+        """
         if not opt_for_new:
             sessions_table = {
                 session["identifier"]: session for session in self.new_sessions

--- a/openstates/scrape/jurisdiction.py
+++ b/openstates/scrape/jurisdiction.py
@@ -103,7 +103,11 @@ class State(BaseModel):
             endpoint,
             params=params,
         )
-        response.raise_for_status()
+
+        try:
+            response.raise_for_status()
+        except requests.RequestException:
+            return []
 
         sessions = []
         for session in response.json():

--- a/openstates/scrape/jurisdiction.py
+++ b/openstates/scrape/jurisdiction.py
@@ -99,12 +99,11 @@ class State(BaseModel):
             }
         """
         params = {"state_name": self.name}
-        response = requests.get(
-            endpoint,
-            params=params,
-        )
-
         try:
+            response = requests.get(
+                endpoint,
+                params=params,
+            )
             response.raise_for_status()
         except requests.RequestException:
             print("No sessions found for ", self.name, " in cronos")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [tool.poetry]
-name = "openstates"
-version = "6.20.1"
-description = "core infrastructure for the openstates project"
-authors = ["James Turk <dev@jamesturk.net>"]
+name = "cyclades"
+version = "1.0.0"
+description = "core infrastructure for the cyclades project"
+authors = ["James Turk <dev@jamesturk.net>", "Daniel Gieseke <daniel@abstract.us>", "Neal P. Patel <neal@abstract.us>"]
 license = "MIT"
 
 [tool.poetry.scripts]


### PR DESCRIPTION
This change looks to re-implement `legislative_sessions` as a property (as opposed to a manually defined list), and retire the legacy `legislative_sessions` as `historical_legislative_sessions`. We include the ability to `opt_for_new` to give us flexibility when re-writing sessions, custom backfill and more. This is particularly relevant when additions are made to the main openstates core and scrapers that include new session information. 