### PR TITLE
DAT-432: Trigger cyclades-scraper rebuild whenever there's changes to this repo.

### DIFF
--- a/.github/workflows/build-scrapers.yml
+++ b/.github/workflows/build-scrapers.yml
@@ -1,0 +1,26 @@
+name: Trigger CI in cyclades-openstates-scrapers
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  trigger-ci:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Trigger CI workflow
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const octokit = github.getOctokit(process.env.GITHUB_TOKEN);
+            const response = await octokit.actions.createWorkflowDispatch({
+              owner: 'washabstract',
+              repo: 'cyclades-openstates-scrapers',
+              workflow_id: 'CI',
+              ref: 'main'
+            });
+            console.log(response);
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
In this P.R, we're adding a workflow to this repository to trigger the CI of the cyclades-scrapers.

The cyclades-scrapers CI will build a new docker image, which will download and install the most recent version of this repository. This allows us to see changes made to the core immediately reflected. Currently, we only see changes made here reflected when separate changes are made at the scraper level.

