### PR TITLE
Change package installation name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "openstates"
+name = "cyclades"
 version = "6.20.13"
 description = "core infrastructure for the openstates project"
 authors = ["James Turk <dev@jamesturk.net>"]
@@ -57,6 +57,11 @@ black = "^22.10.0"
 [tool.poetry.group.dev.dependencies]
 types-jsonschema = "^4.17.0.3"
 types-influxdb-client = "^1.37.0.0"
+
+[tool.poetry.packages]
+include = [
+    { include = "openstates" }
+]
 
 [tool.coverage.run]
 omit = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,10 @@
 [tool.poetry]
 name = "cyclades"
 version = "6.20.13"
+packages = [
+    { include = "openstates" },
+    { include = "openstates/**/*.py" }
+]
 description = "core infrastructure for the openstates project"
 authors = ["James Turk <dev@jamesturk.net>"]
 license = "MIT"
@@ -57,11 +61,6 @@ black = "^22.10.0"
 [tool.poetry.group.dev.dependencies]
 types-jsonschema = "^4.17.0.3"
 types-influxdb-client = "^1.37.0.0"
-
-[tool.poetry.packages]
-include = [
-    { include = "openstates" }
-]
 
 [tool.coverage.run]
 omit = [


### PR DESCRIPTION
In this P.R, we make changes to the pyproject.toml to allow us to install the cyclades-core as 'cyclades' as opposed to 'openstates'. This will require a conjunctive change at the scrapers level. This was inspired by [apache-airflow
](https://github.com/apache/airflow), which is installed as 'apache-airflow' but imported as 'airflow' taking advantage of the naming convention of the directory (we too have the directory named openstates instead of cyclades)

Note that while the package is _installed_ as cyclades, it will still be imported as openstates. That is, we would use

`pip install cyclades`
`poetry add cyclades`

but at the python level, we'd continue to use `from openstates import ...`

This allows us to have our own version (I suggest beginning from 1.0) and implementing version bumps accordingly. Note that we may run into oddities with pulling from the main branch should, but would then avoid the constant issues in the scraper repo when there's conflicting versions between the primary openstates-core branch and ours.