### PR TITLE
Adding Conditional for Vote Events in Cache Block

### DIFF
--- a/openstates/scrape/base.py
+++ b/openstates/scrape/base.py
@@ -194,8 +194,14 @@ class Scraper(scrapelib.Scraper):
                     file_path.index('_data') + len('_data') + 1 :
                 ]
                 jurisdiction = upload_file_path[:2]
-                # Bills will be routed through this conditional
-                if hasattr(obj, 'legislative_session') and obj.legislative_session:
+                # Vote events will be routed through this conditional
+                if hasattr(obj, 'motion_text'):
+                    identifier = obj.bill_identifier
+                    logging.info(
+                            f'Saving vote event from bill {identifier}.'
+                        )
+                # Bills will be routed through this conditional      
+                elif hasattr(obj, 'legislative_session') and obj.legislative_session:
                     session = obj.legislative_session
                     identifier = obj.identifier
                     upload_file_path = (

--- a/openstates/scrape/base.py
+++ b/openstates/scrape/base.py
@@ -198,9 +198,9 @@ class Scraper(scrapelib.Scraper):
                 if hasattr(obj, 'motion_text'):
                     identifier = obj.bill_identifier
                     logging.info(
-                            f'Saving vote event from bill {identifier}.'
-                        )
-                # Bills will be routed through this conditional      
+                        f'Saving vote event from bill {identifier}.'
+                    )
+                # Bills will be routed through this conditional
                 elif hasattr(obj, 'legislative_session') and obj.legislative_session:
                     session = obj.legislative_session
                     identifier = obj.identifier


### PR DESCRIPTION
This PR updates the `save_object` function to process and send vote events to the Kafka cluster. Previously, vote events were not being routed to Kafka due to missing logic in the conditional checks. This change introduces proper handling for vote events alongside bills and ancillary JSONs. The changes have been thoroughly tested locally and with full DAG runs.

**Changes Made:**
- Added a conditional block to detect and process vote events (`if hasattr(obj, 'motion_text')`).
- Logs vote events using the bill identifier and routes them to Kafka for further processing.