### PR TITLE
DAT-496 updated core to write new sessions to cronos

### DIFF
--- a/openstates/cli/update.py
+++ b/openstates/cli/update.py
@@ -334,21 +334,14 @@ def check_session_list(juris: State) -> set[str]:
     active_sessions = set()
     # copy the list to avoid modifying it
     sessions = set(juris.ignored_scraped_sessions)
+    new_cronos_sessions = []
     for session in juris.legislative_sessions:
-        cronos_endpoint = os.environ.get("CRONOS_ENDPOINT") + "/sessions/create"
-        if cronos_endpoint:
-            try:
-                session_create = session.copy()
-                session_create["state_name"] = scraper
-                response = requests.post(
-                    cronos_endpoint, data=session_create, timeout=20
-                )
-                response.raise_for_status()
-            except Exception as e:
-                logger.warning(f"Failed to send session data to CRONOS_ENDPOINT: {e}")
+        if juris.create_session_in_cronos(session):
+            new_cronos_sessions.append(session)
         sessions.add(session.get("_scraped_name", session["identifier"]))
         if session.get("active"):
             active_sessions.add(session.get("identifier"))
+    logger.info(f"New sessions created in Cronos: {new_cronos_sessions}")
     if not active_sessions:
         raise CommandError(f'No active sessions on {scraper}')
 

--- a/openstates/cli/update.py
+++ b/openstates/cli/update.py
@@ -10,7 +10,6 @@ import json
 import logging
 import logging.config
 import os
-import requests
 import sys
 import time
 import traceback

--- a/openstates/scrape/jurisdiction.py
+++ b/openstates/scrape/jurisdiction.py
@@ -85,7 +85,7 @@ class State(BaseModel):
     @property
     def new_sessions(
         self,
-        endpoint: str = os.getenv("CRONOS_ENDPOINT"),
+        endpoint: str = os.getenv("CRONOS_ENDPOINT") + "/sessions/query",
     ):
         """Requires CRONOS_ENDPOINT for getting the legislative sessions. Note that legislative sessions are retrieved as a list of json objects.
 
@@ -98,7 +98,7 @@ class State(BaseModel):
             "classification": "primary", # primary or special
             }
         """
-        params = {"state_name": self.name}
+        params = {"state_names": self.name}
         try:
             response = requests.get(
                 endpoint,
@@ -176,7 +176,7 @@ class State(BaseModel):
                 parent_id=legislature._id,
             )
 
-    def check_session_active(session: dict):
+    def check_session_active(self, session: dict):
         """For a given session dictionary, checks to see if "active" is a denoted field. If it's not, then 'active' is set based on the start_date and end_date"""
         if "active" not in session:
             session["active"] = (

--- a/openstates/scrape/jurisdiction.py
+++ b/openstates/scrape/jurisdiction.py
@@ -186,6 +186,20 @@ class State(BaseModel):
             )
         return session
 
+    def create_session_in_cronos(
+        self,
+        session: dict,
+        cronos_endpoint: str = os.getenv("CRONOS_ENDPOINT") + "/sessions/create",
+    ):
+        try:
+            session["state_name"] = self.name
+            response = requests.post(cronos_endpoint, data=session, timeout=20)
+            response.raise_for_status()
+            return True
+        except Exception as e:
+            print(f"Failed to send new session data to cronos: {e}")
+            return False
+
     def get_session_list(self) -> list[str]:
         raise NotImplementedError()
 


### PR DESCRIPTION
Whenever our scrapers fire up, they compile the legislative sessions hard coded in the scrapers, and combine them with those found in Cronos. We want to be able to write sessions for all jurisdictions to cronos so that we can query all sessions from cronos. To do this, we will:

- Add a method to the `Jurisdiction` class to create a new session in cronos
- Call this method once in the `check_session_list` function in `update.py`

It was considered to handle this solely in the jurisdiction class when the `legislative_sessions` property is called. However, the 'legislative_sessions' is a property called a few times in a scrape, and we want to reduce the load on cronos and the database. `check_session_list` is called once per scrape, and is most appropriate from which to call the new method.