### PR TITLE
serialized the scraped_name field from cronos

### DIFF
--- a/openstates/scrape/jurisdiction.py
+++ b/openstates/scrape/jurisdiction.py
@@ -124,6 +124,7 @@ class State(BaseModel):
                         "name",
                         "start_date",
                         "end_date",
+                        "_scraped_name"
                     ]
                 }
             )


### PR DESCRIPTION
In this P.R, we make a simple, 1 line change to ensure that calling `new_sessions` (which overwrites `historical_legislative_sessions`) includes the [_scraped_name field now returned by cronos](https://github.com/washabstract/cronos/pull/33)