### PR TITLE
DAT-509: Fix Cacheing for OS

### DIFF
--- a/openstates/cli/update.py
+++ b/openstates/cli/update.py
@@ -10,6 +10,7 @@ import json
 import logging
 import logging.config
 import os
+import subprocess
 import sys
 import time
 import traceback
@@ -438,6 +439,14 @@ def do_update(
                     }
                 ]
             )
+            # Archive cache directory to S3 if enabled
+            if os.environ.get('ARCHIVE_CACHE_TO_S3') == 'true':
+                try:
+                    logger.info(f'Syncing cache directory {settings.CACHE_DIR} to S3 bucket {settings.CACHE_BUCKET}')
+                    subprocess.run(['aws', 's3', 'sync', settings.CACHE_DIR, settings.CACHE_BUCKET], check=True)
+                    logger.info('Cache directory successfully synced to S3.')
+                except subprocess.CalledProcessError as e:
+                    logger.error(f'Failed to sync cache directory to S3: {e}')
         # we skip import in realtime mode since this happens via the lambda function
         if 'import' in args.actions and not args.realtime:
             report['import'] = do_import(juris, args)

--- a/openstates/scrape/base.py
+++ b/openstates/scrape/base.py
@@ -219,26 +219,6 @@ class Scraper(scrapelib.Scraper):
                     upload_file_path = (
                         f'{jurisdiction}/{session}/{identifier}/{upload_file_path[3:]}'
                     )
-                    s3_bucket_directory = (
-                        f'{jurisdiction}/{session}/{identifier}'.upper()
-                    )
-                    s3 = boto3.client('s3')
-                    bucket = settings.S3_BILLS_BUCKET
-
-                    # Check if the s3_bucket_directory exists
-                    result = s3.list_objects_v2(
-                        Bucket=bucket, Prefix=s3_bucket_directory
-                    )
-                    if 'Contents' in result:
-                        logging.info(
-                            f'Directory {s3_bucket_directory} exists in bucket {bucket}. Skipping save.'
-                        )
-                        return ()
-                    else:
-                        logging.info(
-                            f'Directory {s3_bucket_directory} does not exist in bucket {bucket}. Beginning save process'
-                        )
-
                 # All other ancillary JSONs will be routed here (e.g. jurisdiction JSONs)
                 else:
                     upload_file_path = f'{jurisdiction}/{"Jurisdiction_Information"}/{upload_file_path[3:]}'

--- a/openstates/scrape/jurisdiction.py
+++ b/openstates/scrape/jurisdiction.py
@@ -124,6 +124,7 @@ class State(BaseModel):
                         "name",
                         "start_date",
                         "end_date",
+                        "_scraped_name"
                     ]
                 }
             )

--- a/openstates/settings.py
+++ b/openstates/settings.py
@@ -22,6 +22,7 @@ SCRAPELIB_VERIFY = verify
 
 CACHE_DIR = os.path.join(os.getcwd(), "_cache")
 SCRAPED_DATA_DIR = os.path.join(os.getcwd(), "_data")
+CACHE_BUCKET = os.environ.get("CACHE_BUCKET")
 
 IMPORT_TRANSFORMERS = {
     "bill": {


### PR DESCRIPTION
In this P.R, we:

- Undo the previous cacheing, which checked the cyclades S3 bucket directly to see if a bill exists before continuing to dump. This not only was ineffective at reducing scrape time, but prevents us from writing vote events or any document past the first into S3
- Implement a download and write to an S3 cacheing bucket at the start and end of a scrape. 
- Note that the nature of openstates scrapers is to dump all HTMLs to a single bucket. While small, this will develop bloat over time as we continue to sync all the scrapes. In the future, we'll want to see if we can stratify by jurisdiction and eventually session to reduce the amount being copied into the image.

### Why?
Each scraper is spun up in a pod, with no cache directory implemented yet. By default, openstates creates a local cache within the scrapers repo titled `_cache` if it doesn't already exist. We are simply initializing and populating that directory. Any new folders created in the directory (new bills and updates to the HTML) are synced to the S3 bucket at the end of the scrape.

We evade the issue of a race condition with other states by only syncing new changes as opposed to trying to overwrite the entire bucket/directory (we walk file-by-file) 