### PR TITLE
Legislative session fix

### DIFF
--- a/openstates/cli/update.py
+++ b/openstates/cli/update.py
@@ -439,7 +439,7 @@ def do_update(
             if os.environ.get('ARCHIVE_CACHE_TO_S3') == 'true':
                 try:
                     logger.info(f'Syncing cache directory {settings.CACHE_DIR} to S3 bucket {settings.CACHE_BUCKET}')
-                    subprocess.run(['aws', 's3', 'sync', settings.CACHE_DIR, settings.CACHE_BUCKET+'/'+juris.name ], check=True)
+                    subprocess.run(['aws', 's3', 'sync', settings.CACHE_DIR, settings.CACHE_BUCKET], check=True)
                     logger.info('Cache directory successfully synced to S3.')
                 except subprocess.CalledProcessError as e:
                     logger.error(f'Failed to sync cache directory to S3: {e}')

--- a/openstates/cli/update.py
+++ b/openstates/cli/update.py
@@ -439,7 +439,7 @@ def do_update(
             if os.environ.get('ARCHIVE_CACHE_TO_S3') == 'true':
                 try:
                     logger.info(f'Syncing cache directory {settings.CACHE_DIR} to S3 bucket {settings.CACHE_BUCKET}')
-                    subprocess.run(['aws', 's3', 'sync', settings.CACHE_DIR, settings.CACHE_BUCKET], check=True)
+                    subprocess.run(['aws', 's3', 'sync', settings.CACHE_DIR, settings.CACHE_BUCKET+'/'+juris.name ], check=True)
                     logger.info('Cache directory successfully synced to S3.')
                 except subprocess.CalledProcessError as e:
                     logger.error(f'Failed to sync cache directory to S3: {e}')

--- a/openstates/cli/update.py
+++ b/openstates/cli/update.py
@@ -334,25 +334,21 @@ def check_session_list(juris: State) -> set[str]:
     active_sessions = set()
     # copy the list to avoid modifying it
     sessions = set(juris.ignored_scraped_sessions)
-    new_cronos_sessions = []
     for session in juris.legislative_sessions:
-        if juris.create_session_in_cronos(session):
-            new_cronos_sessions.append(session)
         sessions.add(session.get("_scraped_name", session["identifier"]))
         if session.get("active"):
             active_sessions.add(session.get("identifier"))
-    logger.info(f"New sessions created in Cronos: {new_cronos_sessions}")
     if not active_sessions:
-        raise CommandError(f'No active sessions on {scraper}')
+        raise CommandError(f"No active sessions on {scraper}")
 
     unaccounted_sessions = list(set(scraped_sessions) - sessions)
     if unaccounted_sessions:
         raise CommandError(
             (
-                'Session(s) {sessions} were reported by {scraper}.get_session_list() '
-                'but were not found in {scraper}.legislative_sessions or '
-                '{scraper}.ignored_scraped_sessions.'
-            ).format(sessions=', '.join(unaccounted_sessions), scraper=scraper)
+                "Session(s) {sessions} were reported by {scraper}.get_session_list() "
+                "but were not found in {scraper}.legislative_sessions or "
+                "{scraper}.ignored_scraped_sessions."
+            ).format(sessions=", ".join(unaccounted_sessions), scraper=scraper)
         )
     stats.write_stats(
         [

--- a/openstates/cli/update.py
+++ b/openstates/cli/update.py
@@ -439,7 +439,7 @@ def do_update(
             if os.environ.get('ARCHIVE_CACHE_TO_S3') == 'true':
                 try:
                     logger.info(f'Syncing cache directory {settings.CACHE_DIR} to S3 bucket {settings.CACHE_BUCKET}')
-                    subprocess.run(['aws', 's3', 'sync', settings.CACHE_DIR, settings.CACHE_BUCKET], check=True)
+                    subprocess.run(['aws', 's3', 'sync', settings.CACHE_DIR, settings.CACHE_BUCKET+'/'+juris.name], check=True)
                     logger.info('Cache directory successfully synced to S3.')
                 except subprocess.CalledProcessError as e:
                     logger.error(f'Failed to sync cache directory to S3: {e}')

--- a/openstates/scrape/base.py
+++ b/openstates/scrape/base.py
@@ -123,9 +123,10 @@ class Scraper(scrapelib.Scraper):
 
         # caching
         if settings.CACHE_DIR:
+            print(settings.CACHE_BUCKET+'/'+self.jurisdiction.name)
             self.info(f"Syncing cache from S3 bucket {settings.CACHE_BUCKET}")
             os.makedirs(settings.CACHE_DIR, exist_ok=True)
-            subprocess.run(['aws', 's3', 'sync', settings.CACHE_BUCKET+'/'+self.jurisdiction.name ], settings.CACHE_DIR, check=True)
+            subprocess.run(['aws', 's3', 'sync', settings.CACHE_BUCKET+'/'+self.jurisdiction.name , settings.CACHE_DIR], check=True)
 
             self.info("Cache sync completed")
             self.cache_storage = scrapelib.FileCache(settings.CACHE_DIR)

--- a/openstates/scrape/base.py
+++ b/openstates/scrape/base.py
@@ -103,15 +103,6 @@ class Scraper(scrapelib.Scraper):
         # output
         self.output_file_path = None
 
-        # caching
-        if settings.CACHE_DIR:
-            self.info(f"Syncing cache from S3 bucket {settings.CACHE_BUCKET}")
-            os.makedirs(settings.CACHE_DIR, exist_ok=True)
-            subprocess.run(['aws', 's3', 'sync', settings.CACHE_BUCKET+'/'+juris.name ], settings.CACHE_DIR, check=True)
-
-            self.info("Cache sync completed")
-            self.cache_storage = scrapelib.FileCache(settings.CACHE_DIR)
-
         if fastmode:
             self.requests_per_minute = 0
             self.cache_write_only = False
@@ -129,6 +120,15 @@ class Scraper(scrapelib.Scraper):
         self.warning = self.logger.warning
         self.error = self.logger.error
         self.critical = self.logger.critical
+
+        # caching
+        if settings.CACHE_DIR:
+            self.info(f"Syncing cache from S3 bucket {settings.CACHE_BUCKET}")
+            os.makedirs(settings.CACHE_DIR, exist_ok=True)
+            subprocess.run(['aws', 's3', 'sync', settings.CACHE_BUCKET+'/'+self.jurisdiction.name ], settings.CACHE_DIR, check=True)
+
+            self.info("Cache sync completed")
+            self.cache_storage = scrapelib.FileCache(settings.CACHE_DIR)
 
         modname = os.environ.get('SCRAPE_OUTPUT_HANDLER')
         if modname is None:

--- a/openstates/scrape/base.py
+++ b/openstates/scrape/base.py
@@ -6,6 +6,7 @@ import jsonschema
 import logging
 import os
 import scrapelib
+import subprocess
 import time
 import uuid
 from collections import defaultdict, OrderedDict
@@ -106,15 +107,8 @@ class Scraper(scrapelib.Scraper):
         if settings.CACHE_DIR:
             self.info(f"Syncing cache from S3 bucket {settings.CACHE_BUCKET}")
             os.makedirs(settings.CACHE_DIR, exist_ok=True)
-            s3 = boto3.resource('s3')
-            bucket = s3.Bucket(settings.CACHE_BUCKET)
-            for obj in bucket.objects.all():
-                # Create local cache structure if it doesn't exist (within the scrapers directory)
-                local_path = os.path.join(settings.CACHE_DIR, obj.key)
-                os.makedirs(os.path.dirname(local_path), exist_ok=True)
-                if not os.path.exists(local_path):
-                    self.debug(f"Downloading {obj.key} to cache")
-                    bucket.download_file(obj.key, local_path)
+            subprocess.run(['aws', 's3', 'sync', settings.CACHE_BUCKET+'/'+juris.name ], settings.CACHE_DIR, check=True)
+
             self.info("Cache sync completed")
             self.cache_storage = scrapelib.FileCache(settings.CACHE_DIR)
 

--- a/openstates/scrape/jurisdiction.py
+++ b/openstates/scrape/jurisdiction.py
@@ -139,7 +139,7 @@ class State(BaseModel):
         """Returns a list of legislative sessions. If opt_for_new is True, it will override the historical sessions with the new ones from cronos. Otherwise,
         any sessions from cronos with the same identifier as the historical ones will not be used.
         """
-        missing_sessions = set(session['identifier'] for session in self.new_sessions) - set(session['identifier'] for session in self.historical_legislative_sessions)
+        missing_sessions = set(session['identifier'] for session in self.historical_legislative_sessions) - set(session['identifier'] for session in self.new_sessions)
         for session in self.historical_legislative_sessions:
             # Check if the session is active, and if not, set it to inactive
             if session["identifier"] in missing_sessions:


### PR DESCRIPTION
Here, we're fixing our cache process and the issue we had with legislative session syncing with cronos. Now, we

- Sync sessions to cronos first before resolving `self.legislative_sessions`
- Adjusted our cache'ing protocol to use the AWS CLI for download as opposed to boto3 client (we already were using it to upload updated cache)
- We update our cache to be stratified by jurisdiction name in the cache bucket, to reduce our read cost from S3 (and reduce scrape time becuase we're not downloading everything!)