### PR TITLE
--backfill in openstates

### DIFF
--- a/openstates/scrape/jurisdiction.py
+++ b/openstates/scrape/jurisdiction.py
@@ -39,6 +39,7 @@ class State(BaseModel):
     legislative_sessions = []
     cronos_created_sessions = []
     extras = {}
+    backfill = []
 
     # non-db properties
     scrapers = {}

--- a/openstates/scrape/schemas/jurisdiction.py
+++ b/openstates/scrape/schemas/jurisdiction.py
@@ -39,6 +39,12 @@ schema = {
                 },
             },
         },
-        "extras": extras,
+        "backfill": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
+        "extras": extras
     },
 }


### PR DESCRIPTION
in this P.R, we're introducing a new arg to core for backfilling different sessions for a state.

We can use the `--backfill` flag followed by any amount of sessions in order to backfill a scrape for any given state (that's not CA).

This can be used with airflow where we can backfill for a single state with a single run using the `--backfill` args in the config.

