### PR TITLE
Cache Block for Fastmode Argument

### DIFF
--- a/openstates/cli/update.py
+++ b/openstates/cli/update.py
@@ -100,13 +100,11 @@ def init_kafka_producer(kafka_cluster_name: str) -> KafkaProducer:
 
 def save_bill_cache(scraper, juris: str, sessions: set[str]):
     """
-    Pull all bill.json files from S3 for the given jurisdiction and sessions.
-    Stores them in memory as a dict: {(session, identifier): bill_dict}
+    Pull all bill.json files from S3 and save them locally for comparison.
+    Directory structure will be /tmp/bill_cache/{JURISDICTION}/{SESSION}/{IDENTIFIER}/bill.json
     """
     s3 = boto3.client("s3")
     bucket = settings.S3_BILLS_BUCKET
-
-    scraper.bill_cache = {}
 
     for session in sessions:
         prefix = f"{juris.upper()}/{session}/"
@@ -120,17 +118,18 @@ def save_bill_cache(scraper, juris: str, sessions: set[str]):
                     try:
                         response = s3.get_object(Bucket=bucket, Key=key)
                         bill_json = json.load(response["Body"])
-                        
-                        # Parse identifier from key like NC/2023/HB 12/bill.json
-                        parts = key.split("/")
-                        if len(parts) >= 3:
-                            session = parts[1]
-                            identifier = parts[2]
-                            scraper.bill_cache[(session, identifier)] = bill_json
+
+                        parts = key.split("/")  # e.g., ["NC", "2025", "HB 123", "bill.json"]
+                        if len(parts) >= 4:
+                            juris_dir, session_dir, identifier = parts[:3]
+                            local_dir = f"/tmp/bill_cache/{juris_dir}/{session_dir}/{identifier}"
+                            logger.info(f"Saving to {local_dir}/bill.json")
+                            os.makedirs(local_dir, exist_ok=True)
+                            with open(f"{local_dir}/bill.json", "w") as f:
+                                json.dump(bill_json, f)
 
                     except Exception as e:
-                        scraper.warning(f"Could not pull {key} from S3: {e}")
-
+                        logger.warning(f"Failed to fetch {key} from S3: {e}")
 
 def do_scrape(
     juris: State,
@@ -173,7 +172,8 @@ def do_scrape(
     )
 
     if args.fastmode:
-        save_bill_cache(jscraper, jscraper.jurisdiction.name, active_sessions)
+        logger.info("Saving bill cache from S3")
+        save_bill_cache(jscraper, vars(args)['module'], active_sessions)
 
     last_scrape_end_datetime = datetime.datetime.utcnow()
     for scraper_name, scrape_args in scrapers.items():
@@ -374,7 +374,7 @@ def check_session_list(juris: State) -> set[str]:
     for session in juris.legislative_sessions:
         sessions.add(session.get("_scraped_name", session["identifier"]))
         session_identifiers.add(session.get("identifier"))
-        if session.get("active") or ("all" in juris.backfill):
+        if session.get("active") or ("all" in getattr(juris, "backfill", [])):
             active_sessions.add(session.get("identifier"))
     active_sessions.update(juris.backfill)
     if not active_sessions:

--- a/openstates/scrape/base.py
+++ b/openstates/scrape/base.py
@@ -237,13 +237,16 @@ class Scraper(scrapelib.Scraper):
 
                 try:
                     self.info(f"Checking for existing bill in s3://{bucket}/{s3_key}")
-                    cached = self.bill_cache.get((session, identifier))
-                    if cached:
+                    local_path = f"/tmp/bill_cache/{jurisdiction}/{session}/{identifier}/bill.json"
+                    if os.path.exists(local_path):
+                        with open(local_path) as f:
+                            existing_json = json.load(f)
                         new_json = obj.as_dict()
                         new_json.pop("_id", None)
-                        cached.pop("_id", None)
-                        if cached == new_json:
-                            self.info(f"Skipping unchanged bill: {jurisdiction}/{session}/{identifier}")
+                        existing_json.pop("_id", None)
+
+                        if existing_json == new_json:
+                            self.info(f"Bill unchanged — skipping save: {jurisdiction}/{session}/{identifier}")
                             return
                 except s3.exceptions.NoSuchKey:
                     self.info(f"Bill not found in S3, saving: {jurisdiction}/{session}/{identifier}")

--- a/openstates/scrape/base.py
+++ b/openstates/scrape/base.py
@@ -221,6 +221,42 @@ class Scraper(scrapelib.Scraper):
             except ValueError:
                 upload_file_path = file_path
 
+            # Fastmode S3 cache check: only for bills
+            if (
+                self.requests_per_minute == 0 and  # fastmode is on
+                hasattr(obj, 'identifier') and
+                hasattr(obj, 'legislative_session')
+            ):
+                identifier = obj.identifier
+                session = obj.legislative_session
+                jurisdiction = upload_file_path[:2].upper()
+                s3_key = f"{jurisdiction}/{session}/{identifier}/bill.json"
+
+                s3 = boto3.client("s3")
+                bucket = settings.S3_BILLS_BUCKET
+
+                try:
+                    self.info(f"Checking for existing bill in s3://{bucket}/{s3_key}")
+                    response = s3.get_object(Bucket=bucket, Key=s3_key)
+                    existing_json = json.load(response["Body"])
+
+                    new_json = json.loads(
+                        json.dumps(obj.as_dict(), cls=utils.JSONEncoderPlus)
+                    )
+
+                    # UUIDs in JSONs Differ Each Scrape Run
+                    new_json.pop("_id", None)
+                    existing_json.pop("_id", None)
+
+                    if existing_json == new_json:
+                        self.info(f"Bill unchanged — skipping save: {jurisdiction}/{session}/{identifier}")
+                        return  # Skip saving
+                except s3.exceptions.NoSuchKey:
+                    self.info(f"Bill not found in S3, saving: {jurisdiction}/{session}/{identifier}")
+                except Exception as e:
+                    self.warning(f"S3 comparison failed for {identifier}: {e}")
+
+
             if self.kafka:  # Send to Kafka only if producer is initialized
                 self.kafka_producer.send(jurisdiction, obj.as_dict())
                 # Kafka producers use batching to optimize throughput and reduce the load on brokers

--- a/openstates/scrape/base.py
+++ b/openstates/scrape/base.py
@@ -221,7 +221,7 @@ class Scraper(scrapelib.Scraper):
             except ValueError:
                 upload_file_path = file_path
 
-            # Fastmode S3 cache check: only for bills
+            # Fastmode S3 cache check
             if (
                 self.requests_per_minute == 0 and  # fastmode is on
                 hasattr(obj, 'identifier') and
@@ -244,7 +244,7 @@ class Scraper(scrapelib.Scraper):
                         json.dumps(obj.as_dict(), cls=utils.JSONEncoderPlus)
                     )
 
-                    # UUIDs in JSONs Differ Each Scrape Run
+                    # UUIDs in JSONs Differ Each Scrape Run, Removing So We Don't Compare
                     new_json.pop("_id", None)
                     existing_json.pop("_id", None)
 


### PR DESCRIPTION
This PR adds logic to the `save_object` method that prevents saving bill JSONs if a bill has not changed from what's already stored in S3. This logic is only enabled when running scrapers in fastmode (`--fastmode`).

**What's new:**
- If fastmode is enabled, and we confirm this scraped object is a bill, the scraper checks S3 (via `S3_BILLS_BUCKET`) for the current bill path.
- If the bill exists, we:
  - Load both the existing and newly scraped bill JSONs.
  - Strip the `_id` field from both (since it's regenerated with each run).
  - Compare the remaining structure.
- If they match, we skip saving and log that the bill was unchanged.
- If the bill is not found in S3, or if there's any error during retrieval, we proceed with saving as usual.

**Why this matters:**
- Reduces unnecessary writes to disk/S3 and avoids overwhelming our Kafka Consumers
- Speeds up bill scraping in fastmode, especially when there are many bills and only a small number of updates.

**Tested with:**
Multiple state scrapers including NC, IA, and NV.  All tests ran as expected.