### PR TITLE
backfill default args

### DIFF
--- a/openstates/scrape/jurisdiction.py
+++ b/openstates/scrape/jurisdiction.py
@@ -38,6 +38,7 @@ class State(BaseModel):
     historical_legislative_sessions = []
     legislative_sessions = []
     cronos_created_sessions = []
+    backfill = []
     extras = {}
 
     # non-db properties


### PR DESCRIPTION
Ugh forgot to add and commit this when making the initial P.R

Default arg for backfill to be none; this way, the standard scrape doesn't freak out when there's no backfill value