### PR TITLE
Ensuring Topics Are Always Uppercase

### DIFF
--- a/openstates/scrape/base.py
+++ b/openstates/scrape/base.py
@@ -256,7 +256,7 @@ class Scraper(scrapelib.Scraper):
 
 
             if self.kafka:  # Send to Kafka only if producer is initialized
-                self.kafka_producer.send(jurisdiction, obj.as_dict())
+                self.kafka_producer.send(jurisdiction.lower(), obj.as_dict())
                 # Kafka producers use batching to optimize throughput and reduce the load on brokers
                 # The delay below ensures messages are sent before the script continues
                 # Documentation: https://kafka.apache.org/documentation/#producerconfigs_linger.ms

--- a/openstates/scrape/base.py
+++ b/openstates/scrape/base.py
@@ -256,7 +256,7 @@ class Scraper(scrapelib.Scraper):
 
 
             if self.kafka:  # Send to Kafka only if producer is initialized
-                self.kafka_producer.send(jurisdiction.lower(), obj.as_dict())
+                self.kafka_producer.send(jurisdiction.upper(), obj.as_dict())
                 # Kafka producers use batching to optimize throughput and reduce the load on brokers
                 # The delay below ensures messages are sent before the script continues
                 # Documentation: https://kafka.apache.org/documentation/#producerconfigs_linger.ms


### PR DESCRIPTION
This PR updates the Kafka publishing logic to ensure that the jurisdiction string used as the topic name is always uppercase.

Currently, in the fastmode cache comparison block, the jurisdiction is converted to uppercase when building S3 paths (e.g., MI/2025-2026/HB 4001/...). However, when sending messages to Kafka, the jurisdiction was being passed as-is, which led to inconsistencies in topic naming (e.g., CA vs ca).

To enforce consistency across our pipeline and prevent issues related to mismatched topic names or consumers missing messages, we now normalize the Kafka topic to uppercase.