### PR TITLE
Fix cache dir sync

### DIFF
--- a/openstates/cli/update.py
+++ b/openstates/cli/update.py
@@ -445,8 +445,8 @@ def do_update(
                     }
                 ]
             )
-            # Archive cache directory to S3 if enabled
-            if os.environ.get('ARCHIVE_CACHE_TO_S3') == 'true':
+            # Update remote S3 cache if ARCHIVE_CACHE_TO_S3 is set
+            if os.environ.get('ARCHIVE_CACHE_TO_S3', 'false').lower() == 'true':
                 try:
                     logger.info(f'Syncing cache directory {settings.CACHE_DIR} to S3 bucket {settings.CACHE_BUCKET}')
                     subprocess.run(['aws', 's3', 'sync', settings.CACHE_DIR, settings.CACHE_BUCKET+'/'+juris.name], check=True)

--- a/openstates/scrape/base.py
+++ b/openstates/scrape/base.py
@@ -224,7 +224,7 @@ class Scraper(scrapelib.Scraper):
             if jurisdiction:
                 must_clauses.append({"term": {"jurisdiction.keyword": jurisdiction}})
             if session:
-                must_clauses.append({"term": {"legislative_session": session}})
+                must_clauses.append({"term": {"legislative_session.keyword": session}})
 
             query = {
                 "query": {"bool": {"must": must_clauses}},

--- a/openstates/scrape/base.py
+++ b/openstates/scrape/base.py
@@ -141,12 +141,12 @@ class Scraper(scrapelib.Scraper):
         # caching
         if settings.CACHE_DIR:
             print(settings.CACHE_BUCKET+'/'+self.jurisdiction.name)
-            self.info(f"Syncing cache from S3 bucket {settings.CACHE_BUCKET}")
-            os.makedirs(settings.CACHE_DIR, exist_ok=True)
-            subprocess.run(['aws', 's3', 'sync', settings.CACHE_BUCKET+'/'+self.jurisdiction.name , settings.CACHE_DIR], check=True)
-
-            self.info("Cache sync completed")
-            self.cache_storage = scrapelib.FileCache(settings.CACHE_DIR)
+            if os.environ.get('SYNC_S3_ARCHIVE', 'false').lower() == 'true':
+                self.info(f"Syncing cache from S3 bucket {settings.CACHE_BUCKET}")
+                os.makedirs(settings.CACHE_DIR, exist_ok=True)
+                subprocess.run(['aws', 's3', 'sync', settings.CACHE_BUCKET+'/'+self.jurisdiction.name , settings.CACHE_DIR], check=True)
+                self.info("Cache sync completed")
+                self.cache_storage = scrapelib.FileCache(settings.CACHE_DIR)
 
         modname = os.environ.get('SCRAPE_OUTPUT_HANDLER')
         if modname is None:


### PR DESCRIPTION
In this P.R, we adjust our handling of arguments and env vars to separate the ability to enable OS cache'ing (through S3) and the ability to activate caching with using es cache

- `fastmode` will choose whether or not we use elastic for cache checking bills
- the `SYNC_S3_ARCHIVE` field will dictate whether or not we sync the remote S3 cache to the local _cache directory
- the 'ARCHIVE_CACHE_TO_S3' field will dictate whether or not we update the remote cache 