### PR TITLE
datetime flattening in json/dictionary flattening

### DIFF
--- a/openstates/scrape/base.py
+++ b/openstates/scrape/base.py
@@ -26,6 +26,8 @@ def replace_none_in_dict(bill_json: dict) -> dict:
         return [replace_none_in_dict(item) for item in bill_json]
     elif bill_json is None:
         return ""
+    elif isinstance(bill_json, datetime.date):
+        return bill_json.strftime('%Y-%m-%d')
     else:
         return bill_json
 


### PR DESCRIPTION
### TL;DR

Added date formatting for datetime.date objects in the `replace_none_in_dict` function.

### What changed?

Added a new condition in the `replace_none_in_dict` function to handle `datetime.date` objects by converting them to ISO format strings (`YYYY-MM-DD`). This ensures that date objects are properly serialized when processing bill data.

### How to test?

1. Create a dictionary containing a `datetime.date` object
2. Pass it through the `replace_none_in_dict` function
3. Verify that the date is converted to a string in the format 'YYYY-MM-DD'

### Why make this change?

When serializing bill data that contains date objects, these objects need to be converted to strings in a consistent format. Without this change, attempting to serialize a dictionary containing date objects would likely result in errors. This fix ensures proper JSON serialization of bill data that includes dates.