### PR TITLE
USA Scraper Cache Fix

### DIFF
--- a/openstates/scrape/base.py
+++ b/openstates/scrape/base.py
@@ -450,11 +450,13 @@ class Scraper(scrapelib.Scraper):
                                 if "date" in action and action["date"]:
                                     date_str = str(action["date"]).strip()
                                     # Only slice if we have at least 10 characters and it looks like a date
-                                    if len(date_str) >= 10 and date_str[4] == '-' and date_str[7] == '-':
-                                        action["date"] = date_str[:10]
-                                    else:
-                                        # Log warning for malformed dates but don't crash
-                                        print(f"Warning: Malformed date format '{date_str}', keeping as-is")
+                                    if len(date_str) >= 10:
+                                        try:
+                                            parsed = datetime.datetime.strptime(date_str[:10], "%Y-%m-%d")
+                                            action["date"] = parsed.date().isoformat()
+                                        except ValueError:
+                                            # Log warning for malformed dates but don't crash
+                                            print(f"Warning: Malformed date format '{date_str}', keeping as-is")
                                 normed.append(action)
                             return normed
 

--- a/openstates/scrape/base.py
+++ b/openstates/scrape/base.py
@@ -327,7 +327,11 @@ class Scraper(scrapelib.Scraper):
         try:
             must_clauses = []
             if jurisdiction:
-                must_clauses.append({"term": {"jurisdiction.keyword": jurisdiction}})
+                import pdb; pdb.set_trace()
+                if jurisdiction == "USA":
+                    must_clauses.append({"term": {"jurisdiction.keyword": "US"}})
+                else:
+                    must_clauses.append({"term": {"jurisdiction.keyword": jurisdiction}})
             if session:
                 must_clauses.append({"term": {"legislative_session.keyword": session}})
 

--- a/openstates/scrape/base.py
+++ b/openstates/scrape/base.py
@@ -445,7 +445,7 @@ class Scraper(scrapelib.Scraper):
                     if existing_json := self.existing_session_bills.get(identifier):
                         new_json = replace_none_in_dict(new_json)
                         existing_json = replace_none_in_dict(existing_json)
-
+                        import pdb; pdb.set_trace()
                         mismatched_fields = {
                             key
                             for key in new_json.keys()

--- a/openstates/scrape/base.py
+++ b/openstates/scrape/base.py
@@ -448,8 +448,13 @@ class Scraper(scrapelib.Scraper):
                             for action in actions:
                                 action = dict(action)
                                 if "date" in action and action["date"]:
-                                    # Only keep YYYY-MM-DD part
-                                    action["date"] = action["date"][:10]
+                                    date_str = str(action["date"]).strip()
+                                    # Only slice if we have at least 10 characters and it looks like a date
+                                    if len(date_str) >= 10 and date_str[4] == '-' and date_str[7] == '-':
+                                        action["date"] = date_str[:10]
+                                    else:
+                                        # Log warning for malformed dates but don't crash
+                                        print(f"Warning: Malformed date format '{date_str}', keeping as-is")
                                 normed.append(action)
                             return normed
 
@@ -515,8 +520,6 @@ class Scraper(scrapelib.Scraper):
             else:
                 with open(file_path, 'w') as f:
                     json.dump(obj.as_dict(), f, cls=utils.JSONEncoderPlus)
-            with open(file_path, "w") as f:
-                json.dump(obj.as_dict(), f, cls=utils.JSONEncoderPlus)
 
             # Periodically push data to GCS by data class
             if self.realtime:

--- a/openstates/scrape/base.py
+++ b/openstates/scrape/base.py
@@ -327,11 +327,7 @@ class Scraper(scrapelib.Scraper):
         try:
             must_clauses = []
             if jurisdiction:
-                import pdb; pdb.set_trace()
-                if jurisdiction == "USA":
-                    must_clauses.append({"term": {"jurisdiction.keyword": "US"}})
-                else:
-                    must_clauses.append({"term": {"jurisdiction.keyword": jurisdiction}})
+                must_clauses.append({"term": {"jurisdiction.keyword": jurisdiction}})
             if session:
                 must_clauses.append({"term": {"legislative_session.keyword": session}})
 
@@ -445,12 +441,31 @@ class Scraper(scrapelib.Scraper):
                     if existing_json := self.existing_session_bills.get(identifier):
                         new_json = replace_none_in_dict(new_json)
                         existing_json = replace_none_in_dict(existing_json)
-                        import pdb; pdb.set_trace()
-                        mismatched_fields = {
-                            key
-                            for key in new_json.keys()
-                            if new_json[key] != existing_json.get(key)
-                        }
+
+                        def normalize_action_dates(actions):
+                            """Normalize action date fields to just the date part for comparison."""
+                            normed = []
+                            for action in actions:
+                                action = dict(action)
+                                if "date" in action and action["date"]:
+                                    # Only keep YYYY-MM-DD part
+                                    action["date"] = action["date"][:10]
+                                normed.append(action)
+                            return normed
+
+                        mismatched_fields = set()
+                        for key in new_json.keys():
+                            new_val = new_json[key]
+                            existing_val = existing_json.get(key)
+                            # Special handling for actions field
+                            if key == "actions" and isinstance(new_val, list) and isinstance(existing_val, list):
+                                normed_new = normalize_action_dates(new_val)
+                                normed_existing = normalize_action_dates(existing_val)
+                                if normed_new != normed_existing:
+                                    mismatched_fields.add(key)
+                            else:
+                                if new_val != existing_val:
+                                    mismatched_fields.add(key)
 
                         if mismatched_fields - {"_id", "jurisdiction", "scraped_at"}:
                             self.info(

--- a/openstates/scrape/tests/test_scraper.py
+++ b/openstates/scrape/tests/test_scraper.py
@@ -166,3 +166,105 @@ def test_whitespace_is_stripped():
     assert b.sources[0]["url"] == "https://example.com/"
     # subject got sorted by pre_save
     assert b.subject == ["one", "three", "two"]
+
+
+def test_normalize_action_dates():
+    """Test date normalization handles various edge cases safely."""
+    # Create scraper in fastmode to enable Elasticsearch comparison
+    s = Scraper(juris, "/tmp/", fastmode=True)
+    
+    # Create a bill with actions
+    b1 = Bill("HB 1", "2023", "Test Bill")
+    b1.add_action("introduced", "2023-01-15T10:30:00Z")
+    b1.add_action("passed", "2023-01-15")
+    b1.add_source("http://example.com")
+    
+    b2 = Bill("HB 1", "2023", "Test Bill")
+    b2.add_action("introduced", "2023-01-15")  # Same date, different format
+    b2.add_action("passed", "2023-01-15")
+    b2.add_source("http://example.com")
+    
+    # These should be considered identical after normalization
+    # We'll test this by mocking the existing_session_bills
+    s.existing_session_bills = {"HB 1": b1.as_dict()}
+    
+    with mock.patch("json.dump") as json_dump:
+        s.save_object(b2)
+    
+    # The bill should NOT be saved because actions are identical after normalization
+    assert len(json_dump.mock_calls) == 0
+
+
+def test_bill_comparison_with_different_action_formats():
+    """Test that bills with different action date formats are properly compared."""
+    # Create scraper in fastmode to enable Elasticsearch comparison
+    s = Scraper(juris, "/tmp/", fastmode=True)
+    
+    # Create two identical bills with different date formats
+    b1 = Bill("HB 1", "2023", "Test Bill")
+    b1.add_action("introduced", "2023-01-15T10:30:00Z")
+    b1.add_source("http://example.com")
+    
+    b2 = Bill("HB 1", "2023", "Test Bill") 
+    b2.add_action("introduced", "2023-01-15")  # Same date, different format
+    b2.add_source("http://example.com")
+    
+    # Mock existing bills
+    s.existing_session_bills = {"HB 1": b1.as_dict()}
+    
+    with mock.patch("json.dump") as json_dump:
+        s.save_object(b2)
+    
+    # Should be considered identical and not saved again
+    assert len(json_dump.mock_calls) == 0
+
+
+def test_bill_comparison_with_different_actions():
+    """Test that bills with genuinely different actions are not considered identical."""
+    s = Scraper(juris, "/tmp/")
+    
+    # Create two bills with different actions
+    b1 = Bill("HB 1", "2023", "Test Bill")
+    b1.add_action("introduced", "2023-01-15")
+    b1.add_source("http://example.com")
+    
+    b2 = Bill("HB 1", "2023", "Test Bill")
+    b2.add_action("introduced", "2023-01-15")
+    b2.add_action("passed", "2023-01-16")  # Additional action
+    b2.add_source("http://example.com")
+    
+    # Mock existing bills
+    s.existing_session_bills = {"HB 1": b1.as_dict()}
+    
+    with mock.patch("json.dump") as json_dump:
+        s.save_object(b2)
+    
+    # Should be considered different and saved
+    assert len(json_dump.mock_calls) == 1
+
+
+def test_normalize_action_dates_edge_cases():
+    """Test edge cases for date normalization that could cause crashes."""
+    s = Scraper(juris, "/tmp/")
+    
+    # Test with valid date formats that should be normalized
+    # (We can't test with invalid dates because the Bill schema validates them)
+    actions = [
+        {"date": "2023-01-15T10:30:00Z", "action": "normal"},  # Should work
+        {"date": "2023-01-15", "action": "already_short"},     # Should work
+        {"date": "  2023-01-15T10:30:00Z  ", "action": "whitespace"},  # Should work
+    ]
+    
+    # Create a bill with these actions
+    b = Bill("HB 1", "2023", "Test Bill")
+    for action in actions:
+        if action["date"]:
+            b.add_action(action["action"], action["date"])
+    b.add_source("http://example.com")
+    
+    # This should not crash
+    with mock.patch("json.dump") as json_dump:
+        s.save_object(b)
+    
+    # Should save successfully
+    assert len(json_dump.mock_calls) == 1


### PR DESCRIPTION
This PR amends the cache logic within the `Scraper` class such that action dates are normalized at the time of deciding whether or not to send bill data for processing.  Previously, the USA scraper was scraping dates in a format that was bypassing our cache--this ensures we aren't reprocessing old bills at time of scrape.

New Function: `normalize_action_dates`

Testing: This was tested with our USA scraper module as well as our CA and NC scraper modules for good measure.