### PR TITLE
HTTP Resilience Arg Update

### DIFF
--- a/openstates/cli/update.py
+++ b/openstates/cli/update.py
@@ -126,7 +126,7 @@ def do_scrape(
         kafka=args.kafka,
         kafka_producer=kafka_producer,
         file_archiving_enabled=args.archive,
-        http_resilience_mode=getattr(args, 'http_resilience', False),
+        http_resilience_mode=args.http_resilience,
     )
     report['jurisdiction'] = jscraper.do_scrape()
     stats.write_stats(
@@ -171,7 +171,7 @@ def do_scrape(
                     kafka=args.kafka,
                     kafka_producer=kafka_producer,
                     file_archiving_enabled=args.archive,
-                    http_resilience_mode=getattr(args, 'http_resilience', False),
+                    http_resilience_mode=args.http_resilience,
                 )
                 partial_report = scraper.do_scrape(**scrape_args, session=session)
                 stats.write_stats(
@@ -209,7 +209,7 @@ def do_scrape(
                 kafka=args.kafka,
                 kafka_producer=kafka_producer,
                 file_archiving_enabled=args.archive,
-                http_resilience_mode=getattr(args, 'http_resilience', False),
+                http_resilience_mode=args.http_resilience,
             )
             report[scraper_name] = scraper.do_scrape(**scrape_args)
             session = scrape_args.get("session", "")

--- a/openstates/cli/update.py
+++ b/openstates/cli/update.py
@@ -126,6 +126,7 @@ def do_scrape(
         kafka=args.kafka,
         kafka_producer=kafka_producer,
         file_archiving_enabled=args.archive,
+        http_resilience_mode=getattr(args, 'http_resilience', False),
     )
     report['jurisdiction'] = jscraper.do_scrape()
     stats.write_stats(
@@ -170,6 +171,7 @@ def do_scrape(
                     kafka=args.kafka,
                     kafka_producer=kafka_producer,
                     file_archiving_enabled=args.archive,
+                    http_resilience_mode=getattr(args, 'http_resilience', False),
                 )
                 partial_report = scraper.do_scrape(**scrape_args, session=session)
                 stats.write_stats(
@@ -207,6 +209,7 @@ def do_scrape(
                 kafka=args.kafka,
                 kafka_producer=kafka_producer,
                 file_archiving_enabled=args.archive,
+                http_resilience_mode=getattr(args, 'http_resilience', False),
             )
             report[scraper_name] = scraper.do_scrape(**scrape_args)
             session = scrape_args.get("session", "")
@@ -617,6 +620,12 @@ def parse_args() -> tuple[argparse.Namespace, list[str]]:
     )
     parser.add_argument(
         "--fastmode", action="store_true", help="use cache and turn off throttling"
+    )
+    parser.add_argument(
+        "--http-resilience", 
+        action="store_true", 
+        dest="http_resilience",
+        help="enable HTTP resilience mode for better connection handling"
     )
 
     # settings overrides

--- a/openstates/scrape/base.py
+++ b/openstates/scrape/base.py
@@ -169,6 +169,15 @@ class Scraper(scrapelib.Scraper):
 
         self.existing_session_bills = None
 
+        # caching
+        if settings.CACHE_DIR:
+            self.cache_storage = scrapelib.FileCache(settings.CACHE_DIR)
+
+        # HTTP resilience initialization
+        if self.http_resilience_mode:
+            self.headers["User-Agent"] = get_random_user_agent()
+            self._create_fresh_session()
+
         # validation
         self.strict_validation = strict_validation
 
@@ -638,7 +647,7 @@ class Scraper(scrapelib.Scraper):
             return super().get(url, **kwargs)
 
     def post(self, url, data=None, json=None, **kwargs):
-        request_func = lambda: super(Scraper, self).post(url, data=data, json=json**kwargs)  # noqa: E731
+        request_func = lambda: super(Scraper, self).post(url, data=data, json=json, **kwargs)  # noqa: E731
         if self.http_resilience_mode:
             return self.request_resiliently(request_func)
         else:

--- a/openstates/scrape/base.py
+++ b/openstates/scrape/base.py
@@ -173,11 +173,6 @@ class Scraper(scrapelib.Scraper):
         if settings.CACHE_DIR:
             self.cache_storage = scrapelib.FileCache(settings.CACHE_DIR)
 
-        # HTTP resilience initialization
-        if self.http_resilience_mode:
-            self.headers["User-Agent"] = get_random_user_agent()
-            self._create_fresh_session()
-
         # validation
         self.strict_validation = strict_validation
 
@@ -191,6 +186,11 @@ class Scraper(scrapelib.Scraper):
         self.warning = self.logger.warning
         self.error = self.logger.error
         self.critical = self.logger.critical
+
+        # HTTP resilience initialization (after logger is set up)
+        if self.http_resilience_mode:
+            self.headers["User-Agent"] = get_random_user_agent()
+            self._create_fresh_session()
 
         # caching
         if settings.CACHE_DIR:


### PR DESCRIPTION
This PR adds support for the `--http-resilience` flag to the os-update command, enabling HTTP connection handling for scrapers that encounter network issues or server-side blocking.  This command has been defined by the main fork, but not used by any of our scrapers as of yet.  This resolves the network issues we were encountering with the MI state website.

NOTE: While this argument works on all scrapers, it slows down scraping significantly and we may want to opt to not using this argument unless needed.