### PR TITLE
Revising Cache Logic to Reprocess Bills with Short Summaries

### DIFF
--- a/openstates/scrape/base.py
+++ b/openstates/scrape/base.py
@@ -487,6 +487,11 @@ class Scraper(scrapelib.Scraper):
                             self.info(
                                 f"Bill changed, saving: {jurisdiction}/{session}/{identifier}"
                             )
+                        # If the bill summary is less than 100 characters, it is inefficient and should be processed
+                        elif len(existing_json.get("bill_summary")) < 100:
+                            self.info(
+                                f"Bill summary inefficient, saving: {jurisdiction}/{session}/{identifier}"
+                            )
                         else:
                             self.info(
                                 f"Bill unchanged — skipping save: {jurisdiction}/{session}/{identifier}"


### PR DESCRIPTION
This PR amends our cache logic such that if a bill has a summary less than 100 characters (which would include bills with the 'Summary unavailable' flag), we send to Kafka to reprocess.  This allows our system to continuously find bills with weak bill summaries for reprocessing.